### PR TITLE
Allow to tap on whole row instead of image

### DIFF
--- a/freeza/freeza/Base.lproj/Main.storyboard
+++ b/freeza/freeza/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="DrB-fV-66k">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="DrB-fV-66k">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Top-->
@@ -12,78 +12,74 @@
             <objects>
                 <tableViewController id="2Fm-PT-q0X" customClass="TopEntriesViewController" customModule="freeza" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="110" sectionHeaderHeight="28" sectionFooterHeight="28" id="z3l-0C-udU">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="EntryTableViewCell" rowHeight="110" id="4pU-iB-mch" customClass="EntryTableViewCell" customModule="freeza" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="92" width="600" height="110"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="110"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4pU-iB-mch" id="qYg-we-90s">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="109"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="110"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZK0-mz-4hc">
                                             <rect key="frame" x="8" y="76" width="584" height="22"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LXD-aI-wb0">
-                                            <rect key="frame" x="106" y="8" width="438" height="24"/>
+                                            <rect key="frame" x="118" y="11" width="228" height="24"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="24" id="ByU-IX-ERC"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Age" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yrj-32-1Xg">
-                                            <rect key="frame" x="106" y="47" width="486" height="21"/>
+                                            <rect key="frame" x="118" y="50" width="276" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="Jej-X3-jhW"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" weight="light" pointSize="16"/>
-                                            <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="textColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Count" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qNH-q5-Qjw">
-                                            <rect key="frame" x="548" y="10" width="44" height="20"/>
-                                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            <rect key="frame" x="350" y="13" width="44" height="20"/>
+                                            <color key="backgroundColor" red="0.66666668653488159" green="0.66666668653488159" blue="0.66666668653488159" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="M9H-Lr-x1s"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4kO-7S-4fe">
-                                            <rect key="frame" x="8" y="8" width="90" height="60"/>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="EIo-nk-vEK">
+                                            <rect key="frame" x="20" y="11" width="90" height="60"/>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="60" id="Qif-1f-QzR"/>
-                                                <constraint firstAttribute="width" secondItem="4kO-7S-4fe" secondAttribute="height" multiplier="3:2" id="gf8-oB-k1u"/>
+                                                <constraint firstAttribute="height" constant="60" id="g3r-YQ-pAI"/>
+                                                <constraint firstAttribute="width" secondItem="EIo-nk-vEK" secondAttribute="height" multiplier="3:2" id="v6I-pI-7DV"/>
                                             </constraints>
-                                            <state key="normal" image="thumbnail-placeholder"/>
-                                            <connections>
-                                                <action selector="thumbnailButtonTapped:" destination="4pU-iB-mch" eventType="touchUpInside" id="QqG-ae-FYm"/>
-                                            </connections>
-                                        </button>
+                                        </imageView>
                                     </subviews>
                                     <constraints>
+                                        <constraint firstItem="EIo-nk-vEK" firstAttribute="top" secondItem="qYg-we-90s" secondAttribute="topMargin" id="0lh-Lb-VDb"/>
                                         <constraint firstItem="qNH-q5-Qjw" firstAttribute="centerY" secondItem="LXD-aI-wb0" secondAttribute="centerY" id="3W5-kr-BTM"/>
-                                        <constraint firstItem="yrj-32-1Xg" firstAttribute="bottom" secondItem="4kO-7S-4fe" secondAttribute="bottom" id="Eoc-Tl-8lU"/>
-                                        <constraint firstAttribute="trailing" secondItem="ZK0-mz-4hc" secondAttribute="trailing" constant="8" id="EvE-70-TSd"/>
+                                        <constraint firstItem="yrj-32-1Xg" firstAttribute="bottom" secondItem="EIo-nk-vEK" secondAttribute="bottom" id="Eoc-Tl-8lU"/>
+                                        <constraint firstAttribute="trailing" secondItem="ZK0-mz-4hc" secondAttribute="trailing" constant="-178" id="EvE-70-TSd"/>
                                         <constraint firstItem="yrj-32-1Xg" firstAttribute="leading" secondItem="LXD-aI-wb0" secondAttribute="leading" id="FCB-za-DOg"/>
-                                        <constraint firstItem="4kO-7S-4fe" firstAttribute="top" secondItem="qYg-we-90s" secondAttribute="topMargin" id="KNi-tI-pkw"/>
-                                        <constraint firstAttribute="bottom" secondItem="ZK0-mz-4hc" secondAttribute="bottom" constant="11" id="ORI-w6-Hv0"/>
-                                        <constraint firstItem="ZK0-mz-4hc" firstAttribute="leading" secondItem="4kO-7S-4fe" secondAttribute="leading" id="UQR-D9-6WJ"/>
-                                        <constraint firstItem="4kO-7S-4fe" firstAttribute="leading" secondItem="qYg-we-90s" secondAttribute="leadingMargin" id="Xfj-aJ-TmR"/>
-                                        <constraint firstItem="LXD-aI-wb0" firstAttribute="leading" secondItem="4kO-7S-4fe" secondAttribute="trailing" constant="8" id="arv-Hg-qLE"/>
-                                        <constraint firstItem="LXD-aI-wb0" firstAttribute="top" secondItem="4kO-7S-4fe" secondAttribute="top" id="lhI-Yc-1tN"/>
+                                        <constraint firstAttribute="bottom" secondItem="ZK0-mz-4hc" secondAttribute="bottom" constant="12" id="ORI-w6-Hv0"/>
+                                        <constraint firstItem="ZK0-mz-4hc" firstAttribute="leading" secondItem="EIo-nk-vEK" secondAttribute="leading" constant="-12" id="UQR-D9-6WJ"/>
+                                        <constraint firstItem="LXD-aI-wb0" firstAttribute="leading" secondItem="EIo-nk-vEK" secondAttribute="trailing" constant="8" id="arv-Hg-qLE"/>
+                                        <constraint firstItem="LXD-aI-wb0" firstAttribute="top" secondItem="EIo-nk-vEK" secondAttribute="top" id="lhI-Yc-1tN"/>
                                         <constraint firstItem="qNH-q5-Qjw" firstAttribute="leading" secondItem="LXD-aI-wb0" secondAttribute="trailing" constant="4" id="n6N-gM-wRl"/>
                                         <constraint firstItem="qNH-q5-Qjw" firstAttribute="trailing" secondItem="qYg-we-90s" secondAttribute="trailingMargin" id="p6l-01-fMF"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="yrj-32-1Xg" secondAttribute="trailing" id="pyC-aE-jjO"/>
-                                        <constraint firstItem="ZK0-mz-4hc" firstAttribute="top" secondItem="4kO-7S-4fe" secondAttribute="bottom" constant="8" id="v85-0u-jdn"/>
+                                        <constraint firstItem="EIo-nk-vEK" firstAttribute="leading" secondItem="qYg-we-90s" secondAttribute="leadingMargin" id="qEi-az-bAb"/>
+                                        <constraint firstItem="ZK0-mz-4hc" firstAttribute="top" secondItem="EIo-nk-vEK" secondAttribute="bottom" constant="5" id="v85-0u-jdn"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>
@@ -91,7 +87,7 @@
                                     <outlet property="authorLabel" destination="LXD-aI-wb0" id="R89-pb-zz9"/>
                                     <outlet property="commentsCountLabel" destination="qNH-q5-Qjw" id="7W9-dc-7qU"/>
                                     <outlet property="entryTitleLabel" destination="ZK0-mz-4hc" id="7dr-ch-tUe"/>
-                                    <outlet property="thumbnailButton" destination="4kO-7S-4fe" id="IPC-Fg-CXE"/>
+                                    <outlet property="thumbnailImageView" destination="EIo-nk-vEK" id="zmz-4m-xTr"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -118,18 +114,18 @@
                         <viewControllerLayoutGuide type="bottom" id="JKD-gb-plb"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="DT3-yg-Xda">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X2P-7D-cVs">
+                            <webView contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X2P-7D-cVs">
                                 <rect key="frame" x="0.0" y="64" width="600" height="536"/>
-                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="deviceRGB"/>
+                                <color key="backgroundColor" red="0.28958413004875183" green="0.31462949514389038" blue="0.32950475811958313" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <outlet property="delegate" destination="aCN-S2-Zc5" id="99D-RQ-d6O"/>
                                 </connections>
                             </webView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="X2P-7D-cVs" firstAttribute="top" secondItem="t9w-D2-lMu" secondAttribute="bottom" id="7bl-fJ-vGO"/>
                             <constraint firstItem="X2P-7D-cVs" firstAttribute="leading" secondItem="DT3-yg-Xda" secondAttribute="leading" id="Cv4-Tw-ah0"/>
@@ -151,7 +147,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DrB-fV-66k" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ahr-2X-kSx">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -164,7 +160,4 @@
             <point key="canvasLocation" x="1716" y="534"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="thumbnail-placeholder" width="90" height="90"/>
-    </resources>
 </document>

--- a/freeza/freeza/EntryTableViewCell.swift
+++ b/freeza/freeza/EntryTableViewCell.swift
@@ -17,34 +17,24 @@ class EntryTableViewCell: UITableViewCell {
         }
     }
     
-    var delegate: EntryTableViewCellDelegate?
-    
-    @IBOutlet private weak var thumbnailButton: UIButton!
+    @IBOutlet private weak var thumbnailImageView: UIImageView!
     @IBOutlet private weak var authorLabel: UILabel!
     @IBOutlet private weak var commentsCountLabel: UILabel!
     @IBOutlet private weak var ageLabel: UILabel!
     @IBOutlet private weak var entryTitleLabel: UILabel!
     
     override func layoutSubviews() {
-        
         super.layoutSubviews()
         self.configureViews()
-    }
-    
-    @IBAction func thumbnailButtonTapped(_ sender: AnyObject) {
-        
-        if let url = self.entry?.url {
-            
-            self.delegate?.presentImage(withURL: url)
-        }
     }
     
     private func configureViews() {
         
         func configureThumbnailImageView() {
         
-            self.thumbnailButton.layer.borderColor = UIColor.black.cgColor
-            self.thumbnailButton.layer.borderWidth = 1
+            self.thumbnailImageView.layer.borderColor = UIColor.black.cgColor
+            self.thumbnailImageView.layer.borderWidth = 1
+            self.thumbnailImageView.contentMode = .scaleToFill
         }
         
         func configureCommentsCountLabel() {
@@ -63,15 +53,14 @@ class EntryTableViewCell: UITableViewCell {
             return
         }
         
-        self.thumbnailButton.setImage(entry.thumbnail, for: [])
+        self.thumbnailImageView.image = entry.thumbnail
         self.authorLabel.text = entry.author
         self.commentsCountLabel.text = entry.commentsCount
         self.ageLabel.text = entry.age
         self.entryTitleLabel.text = entry.title
         
         entry.loadThumbnail { [weak self] in
-            
-            self?.thumbnailButton.setImage(entry.thumbnail, for: [])
+            self?.thumbnailImageView.image = entry.thumbnail
         }
     }
 }

--- a/freeza/freeza/TopEntriesViewController.swift
+++ b/freeza/freeza/TopEntriesViewController.swift
@@ -12,7 +12,6 @@ class TopEntriesViewController: UITableViewController {
     var urlToDisplay: URL?
 
     override func viewDidLoad() {
-        
         super.viewDidLoad()
         
         self.configureViews()
@@ -75,7 +74,7 @@ class TopEntriesViewController: UITableViewController {
         }
 
         func configureTableView() {
-            
+            self.tableView.allowsSelection = true
             self.tableView.rowHeight = UITableViewAutomaticDimension
             self.tableView.estimatedRowHeight = 110.0
 
@@ -133,7 +132,6 @@ class TopEntriesViewController: UITableViewController {
 extension TopEntriesViewController { // UITableViewDataSource
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        
         return self.viewModel.entries.count
     }
     
@@ -142,16 +140,23 @@ extension TopEntriesViewController { // UITableViewDataSource
         let entryTableViewCell = tableView.dequeueReusableCell(withIdentifier: EntryTableViewCell.cellId, for: indexPath as IndexPath) as! EntryTableViewCell
         
         entryTableViewCell.entry = self.viewModel.entries[indexPath.row]
-        entryTableViewCell.delegate = self
         
         return entryTableViewCell
     }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let entry = self.viewModel.entries[indexPath.row]
+        guard let entryURL = entry.url else {
+            // TODO: In the future, we should track or something similar
+            return
+        }
+        self.presentImage(withURL: entryURL)
+    }
 }
 
-extension TopEntriesViewController: EntryTableViewCellDelegate {
+extension TopEntriesViewController {
  
     func presentImage(withURL url: URL) {
-        
         self.urlToDisplay = url
         self.performSegue(withIdentifier: TopEntriesViewController.showImageSegueIdentifier, sender: self)
     }


### PR DESCRIPTION
Allow to tap the whole row instead of the button, by using tableview didSelect delegate method and changing the thumbnail from UIButton to an UIImageView.

Screencast:
![tap_whole_row_2](https://user-images.githubusercontent.com/12101394/81327216-4dd91d00-9071-11ea-9057-9d776c596b2a.gif)
